### PR TITLE
feat: add support to execute scripts

### DIFF
--- a/plugins/envsetup
+++ b/plugins/envsetup
@@ -442,6 +442,17 @@ run_cmd() {
     do_chroot_ae "$chroot_dir" "$command"
 }
 
+run_shell_script() {
+    lshout "Running script: $1"
+    echo
+    echo
+    local script=$1
+    cp -v "$script" "$chroot_dir"
+    chmod +x "$chroot_dir/$(basename $script)"
+    do_chroot_ae "$chroot_dir" /bin/bash "/$script"
+    echo "Done running script: $1"
+}
+
 install_pkg()
 {
     pkg_name="$*"


### PR DESCRIPTION
new `run_shell_script()` to run shell script inside chroot

**requires**: `$chroot_dir`

#### usage
```bash
source plugins/envsetup
chroot_dir="path/to/chroot"
run_shell_script("/path/to/script")
```

> `chroot_dir` variable gets auto-assigned when using `do_build`
>
> intended usage is to use in `addition_setup() {#...}` function 